### PR TITLE
feat: Upgrade react-draggable to v4.5.0 for React 19 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "react": "^18.0.0",
         "react-day-picker": "^9.8.0",
         "react-dom": "^18.0.0",
-        "react-draggable": "^4.4.6",
+        "react-draggable": "^4.5.0",
         "react-hook-form": "^7.51.3",
         "react-quill": "^2.0.0",
         "react-resizable": "^3.0.5",
@@ -13673,9 +13673,10 @@
       }
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -20110,24 +20111,17 @@
       }
     },
     "node_modules/react-draggable": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.6.tgz",
-      "integrity": "sha512-LtY5Xw1zTPqHkVmtM3X8MUOxNDOUhv/khTgBgrUvwaS064bwVvxT+q5El0uUFNx5IEPKXuRejr7UqLwBIg5pdw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
       "dependencies": {
-        "clsx": "^1.1.1",
+        "clsx": "^2.1.1",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
         "react": ">= 16.3.0",
         "react-dom": ">= 16.3.0"
-      }
-    },
-    "node_modules/react-draggable/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react": "^18.0.0",
     "react-day-picker": "^9.8.0",
     "react-dom": "^18.0.0",
-    "react-draggable": "^4.4.6",
+    "react-draggable": "^4.5.0",
     "react-hook-form": "^7.51.3",
     "react-quill": "^2.0.0",
     "react-resizable": "^3.0.5",

--- a/src/packages/master/components/DragResizeModal.tsx
+++ b/src/packages/master/components/DragResizeModal.tsx
@@ -9,6 +9,7 @@ import React, {
   useContext,
   useMemo,
   useState,
+  useRef,
 } from 'react'
 import { createPortal } from 'react-dom'
 import Draggable from 'react-draggable'
@@ -49,6 +50,7 @@ function Open({
 
 function Window({ children, name, className, ...props }: any) {
   const { openName, close } = useContext(ModalContext)!
+  const nodeRef = useRef(null)
 
   const [size, setSize] = useState({
     width: 800,
@@ -70,11 +72,12 @@ function Window({ children, name, className, ...props }: any) {
 
   return createPortal(
     <Draggable
+      nodeRef={nodeRef}
       cancel=".react-resizable-handle, .jsoneditor-react-container"
       defaultClassName="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 cursor-move z-[1000]"
-      positionOffset={{ x: '-50%', y: '-50%' }}
+      // positionOffset={{ x: '-50%', y: '-50%' }}
     >
-      <div style={style}>
+      <div style={style} ref={nodeRef}>
         <ResizableBox
           width={size.width}
           height={size.height}


### PR DESCRIPTION
## Description

This pull request upgrades the react-draggable library to version 4.5.0. This is a necessary update to ensure our application is compatible with the upcoming release of React 19.

The primary motivation for this change is the deprecation of findDOMNode in React 19 and future React versions. Older versions of react-draggable relied on this API, which would cause our draggable components to break.