### PR TITLE
feat(master): add JSON import refactoring, tests, and bug fixes

### DIFF
--- a/packages/master/src/lib/constants/__tests__/url.test.ts
+++ b/packages/master/src/lib/constants/__tests__/url.test.ts
@@ -1,0 +1,37 @@
+import { BaseUrlProvider } from '../url'
+
+describe('BaseUrlProvider', () => {
+  it('should construct URLs with segment', () => {
+    const provider = new BaseUrlProvider('members/v3/jcci')
+
+    expect(provider.SETTINGS_PAGE_URL).toBe('/members/v3/jcci/master-setting')
+    expect(provider.ADD_SETTINGS_PAGE_URL).toBe(
+      '/members/v3/jcci/master-setting/new'
+    )
+    expect(provider.DATA_PAGE_URL).toBe('/members/v3/jcci/master-data')
+    expect(provider.ADD_DATA_PAGE_URL).toBe('/members/v3/jcci/master-data/new')
+    expect(provider.FAQ_CATEGORY_PAGE_URL).toBe('/members/v3/jcci/faq-category')
+    expect(provider.TOP_URL).toBe('/members')
+  })
+
+  it('should construct URLs with empty segment', () => {
+    const provider = new BaseUrlProvider()
+
+    expect(provider.SETTINGS_PAGE_URL).toBe('/master-setting')
+    expect(provider.DATA_PAGE_URL).toBe('/master-data')
+  })
+
+  it('should generate copy setting page URL', () => {
+    const provider = new BaseUrlProvider('app')
+    expect(provider.getCopySettingPageUrl('123')).toBe(
+      '/app/master-setting/123/copy/new'
+    )
+  })
+
+  it('should generate detailed copy setting page URL', () => {
+    const provider = new BaseUrlProvider('app')
+    expect(provider.getDetailedCopySettingPageUrl('123')).toBe(
+      '/app/master-setting/123/copy'
+    )
+  })
+})

--- a/packages/master/src/lib/constants/url.ts
+++ b/packages/master/src/lib/constants/url.ts
@@ -46,7 +46,7 @@ export class BaseUrlProvider implements IUrlProvider {
    */
   constructor(segment: string = '') {
     // 1. Initialize baseUrl first.
-    this.baseUrl = `/${segment}`
+    this.baseUrl = segment ? `/${segment}` : ''
 
     // 2. Now, initialize all dependent properties. This resolves the error.
     this.SETTINGS_PAGE_URL = `${this.baseUrl}/master-setting`
@@ -108,6 +108,9 @@ export const API_URLS = {
   SEQUENCE: {
     WITH_PROVIDED_SETTING: '/sequence/with-provided-setting',
     WITHOUT_PROVIDED_SETTING: '/sequence',
+  },
+  MASTER: {
+    BULK: '/master-bulk/bulk',
   },
   HEALTH: '/',
   CCI: '/master/cci',

--- a/packages/master/src/modules/edit-master-data/components/AddJsonData.tsx
+++ b/packages/master/src/modules/edit-master-data/components/AddJsonData.tsx
@@ -126,7 +126,17 @@ export default function AddJsonData({
   }
 
   const saveData = async () => {
-    const data = JSON.parse(value)
+    let data: any
+    try {
+      data = JSON.parse(value)
+    } catch {
+      toast({
+        title: 'JSON が無効です',
+        description: '正しいJSONフォーマットである必要があります。',
+        variant: 'destructive',
+      })
+      return
+    }
     if (!isValidJsonData(data)) {
       toast({
         title: 'JSON が無効です',

--- a/packages/master/src/modules/edit-master-data/templates/index.tsx
+++ b/packages/master/src/modules/edit-master-data/templates/index.tsx
@@ -64,7 +64,7 @@ const genPlaceholder = (fieldType: string) => {
 }
 
 const getDescription = (code: string, setting: SettingDataEntity) =>
-  setting.attributes.fields.find((field) => field.physicalName === code)
+  setting.attributes?.fields?.find((field) => field.physicalName === code)
     ?.description ?? ''
 
 export default function EditMasterData() {
@@ -113,8 +113,8 @@ export default function EditMasterData() {
   const [readOnly, setReadOnly] = useState<boolean>()
   const [currentSetting, setCurrentSetting] = useState<SettingDataEntity>()
   const [formatData, setFormatData] = useState<DataSettingDataEntity>()
-  const isExistCodeInFields = currentSetting?.attributes.fields
-    .map((field) => field.physicalName)
+  const isExistCodeInFields = currentSetting?.attributes?.fields
+    ?.map((field) => field.physicalName)
     .includes('code')
 
   const [detailInfo, setDetailInfo] = useState<{
@@ -171,7 +171,7 @@ export default function EditMasterData() {
       const processedData = JSON.parse(JSON.stringify(data))
 
       // Iterate through the master setting's field definitions to find JSON fields.
-      currentSetting.attributes.fields.forEach((field) => {
+      currentSetting?.attributes?.fields?.forEach((field) => {
         // Check if the field is of type 'json' and if a value for it exists in the form data.
         if (
           field.dataType === 'json' &&
@@ -217,7 +217,7 @@ export default function EditMasterData() {
         seq = 0
       }
       const settingCode = processedData.settingCode?.split('#')[1]
-      const codeField = currentSetting.attributes.fields.find(
+      const codeField = currentSetting?.attributes?.fields?.find(
         (field) => field.physicalName === 'code'
       )
       let result: DataSettingDataEntity | undefined
@@ -482,7 +482,7 @@ export default function EditMasterData() {
     const formValues = watch()
     const attributes: Record<string, any> = { ...formValues.attributes }
 
-    if (currentSetting?.attributes.fields) {
+    if (currentSetting?.attributes?.fields) {
       currentSetting.attributes.fields.forEach((field) => {
         const fieldName = field.physicalName
         const formValue = formValues.attributes?.[fieldName]
@@ -553,7 +553,7 @@ export default function EditMasterData() {
   useEffect(() => {
     const fetchDataFormat = async () => {
       if (!currentSetting || isEdit) return
-      const settingCodeField = currentSetting.attributes.fields.find(
+      const settingCodeField = currentSetting.attributes?.fields?.find(
         (field) => field.physicalName === 'code'
       )
       if (settingCodeField?.dataType === 'auto_number') {
@@ -781,7 +781,7 @@ export default function EditMasterData() {
                 </>
               )}
 
-              {currentSetting?.attributes.fields?.map((field) => {
+              {currentSetting?.attributes?.fields?.map((field) => {
                 if (field.physicalName === 'code') {
                   if (field.dataType === 'string') {
                     return (

--- a/packages/master/src/modules/edit-master-settings/components/AddJsonData.tsx
+++ b/packages/master/src/modules/edit-master-settings/components/AddJsonData.tsx
@@ -151,7 +151,17 @@ export default function AddJsonData({
   const [value, setValue] = useState<string>('')
 
   const saveData = () => {
-    const data = JSON.parse(value)
+    let data: any
+    try {
+      data = JSON.parse(value)
+    } catch {
+      toast({
+        title: 'JSON が無効です',
+        description: '正しいJSONフォーマットである必要があります。',
+        variant: 'destructive',
+      })
+      return
+    }
     if (!isValidSettingJson(data)) {
       toast({
         title: 'JSON が無効です',

--- a/packages/master/src/modules/edit-master-settings/components/SettingsForm.tsx
+++ b/packages/master/src/modules/edit-master-settings/components/SettingsForm.tsx
@@ -273,7 +273,8 @@ export default function SettingsForm({
         JSON.stringify(form.getValues()) + JSON.stringify(fieldList)
       )
     }
-  }, [editedData, readOnly])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editedData])
 
   useEffect(() => {
     fetchFormatOptions()

--- a/packages/master/src/modules/edit-master-settings/schema.ts
+++ b/packages/master/src/modules/edit-master-settings/schema.ts
@@ -77,10 +77,14 @@ export const mapEntity2Form = (settings: SettingDataEntity) => {
 
   if (
     !settings.attributes.fields
-      .map((field) => field.physicalName)
+      ?.map((field) => field.physicalName)
       .includes('code')
   ) {
-    settings.attributes.fields.unshift(...defaultSettingFields)
+    if (!settings.attributes.fields) {
+      settings.attributes.fields = [...defaultSettingFields]
+    } else {
+      settings.attributes.fields.unshift(...defaultSettingFields)
+    }
   }
   const fieldListData: SettingAttrFields[] = settings.attributes.fields.map(
     (item) => {

--- a/packages/master/src/modules/edit-master-settings/templates/CopyData.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/CopyData.tsx
@@ -76,7 +76,8 @@ export default function CopyMasterSettings() {
       }
     }
     fetchData()
-  }, [params?.pk, params?.sk, loadingStore, httpClient])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params?.pk, params?.sk])
 
   // --- Event Handlers ---
   const handlePaginationChange = (newState: PaginationState) => {

--- a/packages/master/src/modules/edit-master-settings/templates/CopyData.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/CopyData.tsx
@@ -76,7 +76,7 @@ export default function CopyMasterSettings() {
       }
     }
     fetchData()
-  }, [params?.pk, params?.sk])
+  }, [params?.pk, params?.sk, loadingStore, httpClient])
 
   // --- Event Handlers ---
   const handlePaginationChange = (newState: PaginationState) => {

--- a/packages/master/src/modules/edit-master-settings/templates/DetailCopy.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/DetailCopy.tsx
@@ -84,7 +84,7 @@ export default function DetailCopy() {
     }
 
     fetchData()
-  }, [params?.id])
+  }, [params?.id, loadingStore, httpClient])
 
   const handlePaginationChange = (newState: PaginationState) => {
     const newSearchParams = new URLSearchParams(searchParams.toString())

--- a/packages/master/src/modules/edit-master-settings/templates/DetailCopy.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/DetailCopy.tsx
@@ -84,7 +84,8 @@ export default function DetailCopy() {
     }
 
     fetchData()
-  }, [params?.id, loadingStore, httpClient])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params?.id])
 
   const handlePaginationChange = (newState: PaginationState) => {
     const newSearchParams = new URLSearchParams(searchParams.toString())

--- a/packages/master/src/modules/edit-master-settings/templates/NewCopy.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/NewCopy.tsx
@@ -83,7 +83,7 @@ export default function NewCopyMasterSettings() {
   )
   const isExistCodeInFields = useMemo(
     () =>
-      currentSetting?.attributes.fields.some(
+      currentSetting?.attributes?.fields?.some(
         (field) => field.physicalName === 'code'
       ),
     [currentSetting]
@@ -282,7 +282,7 @@ export default function NewCopyMasterSettings() {
     }
 
     const dynamicColumns: ColumnDef<MasterRdsEntity>[] =
-      currentSetting?.attributes.fields
+      currentSetting?.attributes?.fields
         ?.filter((field) => field.isShowedOnList)
         .map((item) => {
           if (item.physicalName === 'code') {

--- a/packages/master/src/modules/edit-master-settings/templates/__tests__/CopyData.test.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/__tests__/CopyData.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import CopyMasterSettings from '../CopyData'
+
+// --- Mocks ---
+
+const mockBack = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: () => ({ back: mockBack, replace: mockReplace }),
+  usePathname: () => '/test',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+jest.mock('../../../../lib/hook/useHealthCheck', () => jest.fn())
+
+// Mock child components to isolate the test
+jest.mock('../../../../components/buttons/back-button', () => ({
+  BackButton: (props: any) => (
+    <button data-testid="back-button" onClick={props.onClickPrev} />
+  ),
+}))
+jest.mock('../../../../components/table/data-table', () => ({
+  DataTable: () => <div data-testid="data-table" />,
+}))
+jest.mock('../../../../components/ui/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}))
+
+const mockSetLoading = jest.fn()
+const mockCloseLoading = jest.fn()
+const mockGet = jest.fn()
+
+jest.mock('../../../../provider', () => ({
+  useHttpClient: () => ({ get: mockGet }),
+  useUrlProvider: () => ({
+    getDetailedCopySettingPageUrl: (id: string) => `/copy/${id}`,
+  }),
+  useUserContext: () => ({ tenantCode: 'TEST_TENANT' }),
+}))
+
+jest.mock('../../../../lib/stores/hooks', () => ({
+  useLoadingStore: () => ({
+    setLoading: mockSetLoading,
+    closeLoading: mockCloseLoading,
+    isLoading: false,
+  }),
+}))
+
+const { useParams } = require('next/navigation')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('CopyMasterSettings', () => {
+  it('calls setLoading → API GET → closeLoading when pk and sk are present', async () => {
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: 'CODE%23001' })
+    mockGet.mockResolvedValue({ data: [] })
+
+    render(<CopyMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockGet).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/tasks/sfn-task-parent',
+      expect.objectContaining({ params: expect.any(Object) })
+    )
+
+    // Verify the correct order: setLoading before closeLoading
+    const setLoadingOrder = mockSetLoading.mock.invocationCallOrder[0]
+    const closeLoadingOrder = mockCloseLoading.mock.invocationCallOrder[0]
+    expect(setLoadingOrder).toBeLessThan(closeLoadingOrder)
+  })
+
+  it('does not fetch when pk is undefined', async () => {
+    useParams.mockReturnValue({ pk: undefined, sk: 'CODE%23001' })
+
+    render(<CopyMasterSettings />)
+
+    // Wait a tick to ensure useEffect has had time to run
+    await waitFor(() => {
+      expect(mockSetLoading).not.toHaveBeenCalled()
+    })
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when sk is undefined', async () => {
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: undefined })
+
+    render(<CopyMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).not.toHaveBeenCalled()
+    })
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('calls closeLoading in finally block when API throws an error', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: 'CODE%23001' })
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    render(<CopyMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch copy results:',
+      expect.any(Error)
+    )
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/packages/master/src/modules/edit-master-settings/templates/__tests__/DetailCopy.test.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/__tests__/DetailCopy.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import DetailCopy from '../DetailCopy'
+
+// --- Mocks ---
+
+const mockBack = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: () => ({ back: mockBack, replace: mockReplace }),
+  usePathname: () => '/test',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+// Mock child components to isolate the test
+jest.mock('../../../../components/buttons/back-button', () => ({
+  BackButton: (props: any) => (
+    <button data-testid="back-button" onClick={props.onClickPrev} />
+  ),
+}))
+jest.mock('../../../../components/table/data-table', () => ({
+  DataTable: () => <div data-testid="data-table" />,
+}))
+jest.mock('../../../../components/ui/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}))
+
+const mockSetLoading = jest.fn()
+const mockCloseLoading = jest.fn()
+const mockGet = jest.fn()
+
+jest.mock('../../../../provider', () => ({
+  useHttpClient: () => ({ get: mockGet }),
+}))
+
+jest.mock('../../../../lib/stores/hooks', () => ({
+  useLoadingStore: () => ({
+    setLoading: mockSetLoading,
+    closeLoading: mockCloseLoading,
+    isLoading: false,
+  }),
+}))
+
+const { useParams } = require('next/navigation')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('DetailCopy', () => {
+  it('calls setLoading → API GET → closeLoading when id is present', async () => {
+    useParams.mockReturnValue({
+      pk: 'TENANT%23SETTING',
+      sk: 'CODE%23001',
+      id: 'TASK%23001%23SUB%23002',
+    })
+    mockGet.mockResolvedValue({ data: [] })
+
+    render(<DetailCopy />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockGet).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(mockGet).toHaveBeenCalledWith(expect.stringContaining('/tasks/'))
+
+    // Verify the correct order: setLoading before closeLoading
+    const setLoadingOrder = mockSetLoading.mock.invocationCallOrder[0]
+    const closeLoadingOrder = mockCloseLoading.mock.invocationCallOrder[0]
+    expect(setLoadingOrder).toBeLessThan(closeLoadingOrder)
+  })
+
+  it('does not fetch when id is undefined', async () => {
+    useParams.mockReturnValue({
+      pk: 'TENANT%23SETTING',
+      sk: 'CODE%23001',
+      id: undefined,
+    })
+
+    render(<DetailCopy />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).not.toHaveBeenCalled()
+    })
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('calls closeLoading in finally block when API throws an error', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    useParams.mockReturnValue({
+      pk: 'TENANT%23SETTING',
+      sk: 'CODE%23001',
+      id: 'TASK%23001%23SUB%23002',
+    })
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    render(<DetailCopy />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch task details:',
+      expect.any(Error)
+    )
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/packages/master/src/modules/edit-master-settings/templates/__tests__/index.test.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/__tests__/index.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import EditMasterSettings from '../index'
+
+// --- Mocks ---
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}))
+
+jest.mock('../../../../lib/hook/useHealthCheck', () => jest.fn())
+
+// Mock SettingsForm to avoid rendering the full form tree
+jest.mock('../../components/SettingsForm', () => {
+  return function MockSettingsForm(props: any) {
+    return <div data-testid="settings-form" />
+  }
+})
+
+// Mock dynamic imports used in the component
+jest.mock('../../../../components/JsonEditor', () => ({}))
+jest.mock('../../../../components/RichTextEditor', () => ({}))
+
+const mockSetLoading = jest.fn()
+const mockCloseLoading = jest.fn()
+const mockGet = jest.fn()
+
+jest.mock('../../../../provider', () => ({
+  useHttpClient: () => ({ get: mockGet }),
+}))
+
+jest.mock('../../../../lib/stores/hooks', () => ({
+  useLoadingStore: () => ({
+    setLoading: mockSetLoading,
+    closeLoading: mockCloseLoading,
+    isLoading: false,
+  }),
+}))
+
+const { useParams } = require('next/navigation')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('EditMasterSettings', () => {
+  it('calls setLoading → API GET → closeLoading when pk and sk are present', async () => {
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: 'CODE%23001' })
+    mockGet.mockResolvedValue({
+      data: { pk: 'TENANT#SETTING', sk: 'CODE#001', name: 'test' },
+    })
+
+    render(<EditMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockGet).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('/master-setting/detail/')
+    )
+
+    // Verify the correct order: setLoading before closeLoading
+    const setLoadingOrder = mockSetLoading.mock.invocationCallOrder[0]
+    const closeLoadingOrder = mockCloseLoading.mock.invocationCallOrder[0]
+    expect(setLoadingOrder).toBeLessThan(closeLoadingOrder)
+  })
+
+  it('calls setLoading → closeLoading without API call when pk is undefined', async () => {
+    useParams.mockReturnValue({ pk: undefined, sk: 'CODE%23001' })
+
+    render(<EditMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('calls setLoading → closeLoading without API call when sk is undefined', async () => {
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: undefined })
+
+    render(<EditMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(mockGet).not.toHaveBeenCalled()
+  })
+
+  it('calls closeLoading in finally block when API throws an error', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+    useParams.mockReturnValue({ pk: 'TENANT%23SETTING', sk: 'CODE%23001' })
+    mockGet.mockRejectedValue(new Error('Network error'))
+
+    render(<EditMasterSettings />)
+
+    await waitFor(() => {
+      expect(mockSetLoading).toHaveBeenCalled()
+      expect(mockCloseLoading).toHaveBeenCalled()
+    })
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch setting data:',
+      expect.any(Error)
+    )
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/packages/master/src/modules/edit-master-settings/templates/index.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/index.tsx
@@ -46,7 +46,7 @@ export default function EditMasterSettings() {
     }
 
     fetchData()
-  }, [params.pk, params.sk])
+  }, [params.pk, params.sk, loadingStore, httpClient])
 
   return <SettingsForm editedData={editedData} setEditedData={setEditedData} />
 }

--- a/packages/master/src/modules/edit-master-settings/templates/index.tsx
+++ b/packages/master/src/modules/edit-master-settings/templates/index.tsx
@@ -46,7 +46,8 @@ export default function EditMasterSettings() {
     }
 
     fetchData()
-  }, [params.pk, params.sk, loadingStore, httpClient])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.pk, params.sk])
 
   return <SettingsForm editedData={editedData} setEditedData={setEditedData} />
 }

--- a/packages/master/src/modules/master-data/components/ActionBar/AddJsonData.tsx
+++ b/packages/master/src/modules/master-data/components/ActionBar/AddJsonData.tsx
@@ -170,7 +170,7 @@ export default function AddJsonData({
       setOpen(false)
       setExpectedCount(0)
       toast({
-        title: 'データ登録に失敗しました。',
+        title: 'データ反映に失敗しました。',
         description:
           'タイムアウトしました。入力内容を確認した上で再度やり直してください。',
         variant: 'destructive',
@@ -185,7 +185,7 @@ export default function AddJsonData({
 
     // Show toast for each completed item
     toast({
-      description: `登録しました (${finishedCount}/${expectedCount})`,
+      description: `反映しました (${finishedCount}/${expectedCount})`,
       variant: 'success',
     })
 
@@ -202,7 +202,17 @@ export default function AddJsonData({
   }, [finishedCount, expectedCount, savedValue, onSave, toast, stop])
 
   const saveData = async () => {
-    const data = JSON.parse(value)
+    let data: any
+    try {
+      data = JSON.parse(value)
+    } catch {
+      toast({
+        title: 'JSON が無効です',
+        description: '正しいJSONフォーマットである必要があります。',
+        variant: 'destructive',
+      })
+      return
+    }
     if (!isValidJsonData(data)) {
       toast({
         title: 'JSON が無効です',
@@ -226,23 +236,32 @@ export default function AddJsonData({
       console.error(error)
       setSubmitting(false)
       setExpectedCount(0)
-    }
-
-    if (!res?.[0].requestId) {
-      setSubmitting(false)
-      setExpectedCount(0)
       toast({
-        title: 'データ登録に失敗しました。',
-        description: '入力内容を確認した上で再度やり直してください。',
+        title: 'データ反映に失敗しました。',
         variant: 'destructive',
       })
+      return
+    }
+
+    const itemsWithRequestId = res.filter((item) => item.requestId)
+    if (itemsWithRequestId.length === 0) {
+      // All items had no changes (not dirty)
+      setSubmitting(false)
+      setOpen(false)
+      setExpectedCount(0)
+      toast({
+        description: 'データに変更はありませんでした。',
+        variant: 'success',
+      })
+      onSave(
+        res.map((item) => ({ ...item, sk: removeSortKeyVersion(item.sk) }))
+      )
     } else {
-      // Set expected count based on response length
-      setExpectedCount(res.length)
+      setExpectedCount(itemsWithRequestId.length)
       setSavedValue(
         res.map((item) => ({ ...item, sk: removeSortKeyVersion(item.sk) }))
       )
-      start(res[0].requestId)
+      start(itemsWithRequestId[0].requestId)
     }
   }
 

--- a/packages/master/src/modules/master-data/components/ActionBar/__tests__/AddJsonData.test.tsx
+++ b/packages/master/src/modules/master-data/components/ActionBar/__tests__/AddJsonData.test.tsx
@@ -1,0 +1,274 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+// --- Mocks ---
+
+const mockToast = jest.fn()
+jest.mock('../../../../../components/ui/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+    toasts: [],
+    dismiss: jest.fn(),
+  }),
+}))
+
+const mockPost = jest.fn()
+jest.mock('../../../../../provider', () => ({
+  useHttpClient: () => ({
+    post: mockPost,
+  }),
+}))
+
+const mockStart = jest.fn()
+const mockStop = jest.fn()
+let subscribedFinishedCount = 0
+
+jest.mock('../../../../../lib/hook/useSubscribeMessage', () => ({
+  useSubscribeBulkCommandStatus: (
+    _tenantCode: string,
+    onTimeout: () => void
+  ) => {
+    return {
+      start: mockStart,
+      stop: mockStop,
+      finishedCount: subscribedFinishedCount,
+    }
+  },
+}))
+
+jest.mock('../../../../../lib/utils/removeSortKeyVersion', () => ({
+  removeSortKeyVersion: (sk: string) => sk.replace(/@.*$/, ''),
+}))
+
+const mockRouterRefresh = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+  useSearchParams: () => ({
+    get: () => 'MASTER#SETTING_CODE',
+  }),
+}))
+
+jest.mock('next/dynamic', () => () => {
+  return function DynamicComponent() {
+    return null
+  }
+})
+
+let mockOnChangeText: ((json: string) => void) | null = null
+jest.mock('../../../../../components/JSONEditorComponent', () => {
+  return function MockJSONEditor({
+    text,
+    onChangeText,
+  }: {
+    text: string
+    onChangeText: (json: string) => void
+  }) {
+    mockOnChangeText = onChangeText
+    return <textarea data-testid="json-editor" defaultValue={text} />
+  }
+})
+
+jest.mock('../../../../../components/DragResizeModal', () => {
+  const Modal = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  Modal.Open = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  Modal.Window = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  return Modal
+})
+
+jest.mock('../../../../../components/buttons/DownloadJSONButton', () => {
+  return function MockDownloadButton() {
+    return null
+  }
+})
+
+jest.mock('../../../../../components/buttons/ImportJSONButton', () => {
+  return function MockImportButton() {
+    return null
+  }
+})
+
+// Import after mocks
+import AddJsonData from '../AddJsonData'
+
+// Helper to set JSON value and trigger save
+async function setValueAndSave(jsonStr: string) {
+  await act(async () => {
+    mockOnChangeText?.(jsonStr)
+  })
+  const saveButton = screen.getByText('データ反映')
+  await act(async () => {
+    fireEvent.click(saveButton)
+  })
+}
+
+describe('master-data/ActionBar/AddJsonData', () => {
+  const mockOnSave = jest.fn()
+  const defaultProps = {
+    tenantCode: 'TEST_TENANT',
+    onSave: mockOnSave,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    subscribedFinishedCount = 0
+    mockOnChangeText = null
+  })
+
+  it('should call API with valid data and start subscription', async () => {
+    const responseData = [
+      {
+        pk: 'MASTER#TEST_TENANT',
+        sk: 'SETTING_CODE#CODE_1@1',
+        id: 'id-1',
+        code: 'CODE_1',
+        name: 'Item 1',
+        version: 1,
+        requestId: 'req-1',
+        attributes: { key: 'val' },
+        seq: 1,
+      },
+    ]
+    mockPost.mockResolvedValue({ data: responseData })
+
+    render(<AddJsonData {...defaultProps} />)
+
+    await setValueAndSave(
+      JSON.stringify([
+        {
+          settingCode: 'SETTING_CODE',
+          code: 'CODE_1',
+          name: 'Item 1',
+          seq: 1,
+          attributes: { key: 'val' },
+        },
+      ])
+    )
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          items: expect.arrayContaining([
+            expect.objectContaining({ code: 'CODE_1' }),
+          ]),
+        })
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockStart).toHaveBeenCalledWith('req-1')
+    })
+  })
+
+  it('should show error toast on invalid JSON data', async () => {
+    render(<AddJsonData {...defaultProps} />)
+
+    // Set JSON that fails validation (missing settingCode)
+    await setValueAndSave(
+      JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+    )
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'JSON が無効です',
+          variant: 'destructive',
+        })
+      )
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+
+  it('should show error toast on API failure', async () => {
+    mockPost.mockRejectedValue(new Error('Network error'))
+
+    render(<AddJsonData {...defaultProps} />)
+
+    await setValueAndSave(
+      JSON.stringify([
+        {
+          settingCode: 'SETTING_CODE',
+          code: 'CODE_1',
+          name: 'Item 1',
+          seq: 1,
+          attributes: {},
+        },
+      ])
+    )
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'データ反映に失敗しました。',
+          variant: 'destructive',
+        })
+      )
+    })
+  })
+
+  it('should show "no changes" toast when no items have requestId', async () => {
+    const responseData = [
+      {
+        pk: 'MASTER#TEST_TENANT',
+        sk: 'SETTING_CODE#CODE_1@1',
+        id: 'id-1',
+        code: 'CODE_1',
+        name: 'Item 1',
+        version: 1,
+        attributes: {},
+        seq: 1,
+      },
+    ]
+    mockPost.mockResolvedValue({ data: responseData })
+
+    render(<AddJsonData {...defaultProps} />)
+
+    await setValueAndSave(
+      JSON.stringify([
+        {
+          settingCode: 'SETTING_CODE',
+          code: 'CODE_1',
+          name: 'Item 1',
+          seq: 1,
+          attributes: {},
+        },
+      ])
+    )
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'データに変更はありませんでした。',
+          variant: 'success',
+        })
+      )
+    })
+    expect(mockOnSave).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ sk: 'SETTING_CODE#CODE_1' }),
+      ])
+    )
+  })
+
+  it('should show error toast for malformed JSON string', async () => {
+    render(<AddJsonData {...defaultProps} />)
+
+    await setValueAndSave('not valid json {{{')
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'JSON が無効です',
+          variant: 'destructive',
+        })
+      )
+    })
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/packages/master/src/modules/master-data/templates/index.tsx
+++ b/packages/master/src/modules/master-data/templates/index.tsx
@@ -83,8 +83,8 @@ export default function MasterData() {
     AccordionValue.DATA_RESULT,
   ])
 
-  const isExistCodeInFields = currentSetting?.attributes.fields
-    .map((field) => field.physicalName)
+  const isExistCodeInFields = currentSetting?.attributes?.fields
+    ?.map((field) => field.physicalName)
     .includes('code')
 
   const { form, loading, loadingStore, control, handleSubmit, reset, errors } =
@@ -190,7 +190,7 @@ export default function MasterData() {
   const columns: ColumnDef<MasterRdsEntity>[] = useMemo(() => {
     // First, define the dynamically generated columns from the settings
     const dynamicColumns: ColumnDef<MasterRdsEntity>[] =
-      currentSetting?.attributes.fields
+      currentSetting?.attributes?.fields
         ?.filter((field) => field.isShowedOnList)
         .map((item) => {
           // Special case for the 'code' column with a link

--- a/packages/master/src/modules/master-settings/__tests__/schema.test.ts
+++ b/packages/master/src/modules/master-settings/__tests__/schema.test.ts
@@ -1,0 +1,369 @@
+import {
+  isValidSettingJson,
+  isValidMasterDataJson,
+  isValidBulkJson,
+  sampleSettingJson,
+  sampleMixedJson,
+} from '../schema'
+
+describe('master-settings/schema', () => {
+  describe('isValidSettingJson', () => {
+    it('valid data returns true', () => {
+      const data = [
+        {
+          code: 'CODE',
+          name: '名前',
+          attributes: {
+            description: '',
+            fields: [
+              {
+                physicalName: 'code',
+                name: 'コード',
+                dataType: 'string',
+                isRequired: true,
+                isShowedOnList: true,
+              },
+            ],
+          },
+        },
+      ]
+      expect(isValidSettingJson(data)).toBe(true)
+    })
+
+    it('array of multiple items returns true', () => {
+      const data = [
+        {
+          code: 'A',
+          name: 'A名',
+          attributes: {
+            fields: [
+              {
+                physicalName: 'f1',
+                name: 'F1',
+                dataType: 'string',
+                isRequired: false,
+                isShowedOnList: false,
+              },
+            ],
+          },
+        },
+        {
+          code: 'B',
+          name: 'B名',
+          attributes: {
+            fields: [
+              {
+                physicalName: 'f2',
+                name: 'F2',
+                dataType: 'number',
+                isRequired: true,
+                isShowedOnList: true,
+              },
+            ],
+          },
+        },
+      ]
+      expect(isValidSettingJson(data)).toBe(true)
+    })
+
+    it('non-array returns false', () => {
+      expect(isValidSettingJson({})).toBe(false)
+      expect(isValidSettingJson('string')).toBe(false)
+      expect(isValidSettingJson(null)).toBe(false)
+      expect(isValidSettingJson(undefined)).toBe(false)
+      expect(isValidSettingJson(42)).toBe(false)
+    })
+
+    it('empty array returns true (no items to validate)', () => {
+      expect(isValidSettingJson([])).toBe(true)
+    })
+
+    it('non-object item returns false', () => {
+      expect(isValidSettingJson(['string'])).toBe(false)
+      expect(isValidSettingJson([null])).toBe(false)
+      expect(isValidSettingJson([42])).toBe(false)
+    })
+
+    it('missing code returns false', () => {
+      const data = [{ name: '名前', attributes: { fields: [] } }]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('missing name returns false', () => {
+      const data = [{ code: 'CODE', attributes: { fields: [] } }]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('missing attributes returns false', () => {
+      const data = [{ code: 'CODE', name: '名前' }]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('non-object attributes returns false', () => {
+      const data = [{ code: 'CODE', name: '名前', attributes: 'string' }]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('non-array fields returns false', () => {
+      const data = [
+        { code: 'CODE', name: '名前', attributes: { fields: 'invalid' } },
+      ]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('missing fields returns false', () => {
+      const data = [
+        { code: 'CODE', name: '名前', attributes: { description: '' } },
+      ]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('missing physicalName in field returns false', () => {
+      const data = [
+        {
+          code: 'CODE',
+          name: '名前',
+          attributes: {
+            fields: [
+              {
+                name: 'F',
+                dataType: 'string',
+                isRequired: true,
+                isShowedOnList: true,
+              },
+            ],
+          },
+        },
+      ]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+
+    it('non-boolean isRequired in field returns false', () => {
+      const data = [
+        {
+          code: 'CODE',
+          name: '名前',
+          attributes: {
+            fields: [
+              {
+                physicalName: 'f',
+                name: 'F',
+                dataType: 'string',
+                isRequired: 'yes',
+                isShowedOnList: true,
+              },
+            ],
+          },
+        },
+      ]
+      expect(isValidSettingJson(data)).toBe(false)
+    })
+  })
+
+  describe('isValidMasterDataJson', () => {
+    it('valid data returns true', () => {
+      const data = [
+        {
+          settingCode: 'SETTING',
+          code: 'CODE',
+          name: '名前',
+          seq: 0,
+          attributes: { description: '' },
+        },
+      ]
+      expect(isValidMasterDataJson(data)).toBe(true)
+    })
+
+    it('non-array returns false', () => {
+      expect(isValidMasterDataJson({})).toBe(false)
+      expect(isValidMasterDataJson(null)).toBe(false)
+    })
+
+    it('missing settingCode returns false', () => {
+      const data = [{ code: 'CODE', name: '名前', seq: 0, attributes: {} }]
+      expect(isValidMasterDataJson(data)).toBe(false)
+    })
+
+    it('non-numeric seq returns false', () => {
+      const data = [
+        {
+          settingCode: 'S',
+          code: 'C',
+          name: 'N',
+          seq: '0',
+          attributes: {},
+        },
+      ]
+      expect(isValidMasterDataJson(data)).toBe(false)
+    })
+
+    it('non-object attributes returns false', () => {
+      const data = [
+        {
+          settingCode: 'S',
+          code: 'C',
+          name: 'N',
+          seq: 0,
+          attributes: 'invalid',
+        },
+      ]
+      expect(isValidMasterDataJson(data)).toBe(false)
+    })
+
+    it('non-object item returns false', () => {
+      expect(isValidMasterDataJson([null])).toBe(false)
+      expect(isValidMasterDataJson([42])).toBe(false)
+    })
+  })
+
+  describe('sampleSettingJson', () => {
+    it('should be valid JSON', () => {
+      const parsed = JSON.parse(sampleSettingJson)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed.length).toBeGreaterThan(0)
+    })
+
+    it('should pass isValidSettingJson validation', () => {
+      const parsed = JSON.parse(sampleSettingJson)
+      expect(isValidSettingJson(parsed)).toBe(true)
+    })
+  })
+
+  describe('isValidBulkJson', () => {
+    it('valid mixed array (settings + data) returns true', () => {
+      const data = [
+        {
+          code: 'SETTING_1',
+          name: '設定1',
+          attributes: { fields: [] },
+        },
+        {
+          settingCode: 'SETTING_1',
+          code: 'DATA_1',
+          name: 'データ1',
+          seq: 0,
+          attributes: { key: 'val' },
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(true)
+    })
+
+    it('valid settings-only array returns true', () => {
+      const data = [
+        {
+          code: 'S1',
+          name: '設定',
+          attributes: { description: '' },
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(true)
+    })
+
+    it('valid data-only array returns true', () => {
+      const data = [
+        {
+          settingCode: 'S1',
+          code: 'D1',
+          name: 'データ',
+          seq: 1,
+          attributes: {},
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(true)
+    })
+
+    it('empty array returns true', () => {
+      expect(isValidBulkJson([])).toBe(true)
+    })
+
+    it('non-array input returns false', () => {
+      expect(isValidBulkJson({})).toBe(false)
+      expect(isValidBulkJson('string')).toBe(false)
+      expect(isValidBulkJson(null)).toBe(false)
+      expect(isValidBulkJson(undefined)).toBe(false)
+      expect(isValidBulkJson(42)).toBe(false)
+    })
+
+    it('missing code returns false', () => {
+      const data = [{ name: 'N', attributes: {} }]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('missing name returns false', () => {
+      const data = [{ code: 'C', attributes: {} }]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('missing attributes returns false', () => {
+      const data = [{ code: 'C', name: 'N' }]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('non-object attributes returns false', () => {
+      const data = [{ code: 'C', name: 'N', attributes: 'invalid' }]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('settingCode present but seq missing returns false', () => {
+      const data = [
+        {
+          settingCode: 'S1',
+          code: 'D1',
+          name: 'データ',
+          attributes: {},
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('settingCode present but seq is non-number returns false', () => {
+      const data = [
+        {
+          settingCode: 'S1',
+          code: 'D1',
+          name: 'データ',
+          seq: '0',
+          attributes: {},
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('settingCode is non-string returns false', () => {
+      const data = [
+        {
+          settingCode: 123,
+          code: 'D1',
+          name: 'データ',
+          seq: 0,
+          attributes: {},
+        },
+      ]
+      expect(isValidBulkJson(data)).toBe(false)
+    })
+
+    it('non-object item returns false', () => {
+      expect(isValidBulkJson([null])).toBe(false)
+      expect(isValidBulkJson([42])).toBe(false)
+      expect(isValidBulkJson(['string'])).toBe(false)
+    })
+  })
+
+  describe('sampleMixedJson', () => {
+    it('should be valid JSON', () => {
+      const parsed = JSON.parse(sampleMixedJson)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed.length).toBe(2)
+    })
+
+    it('first item should be in Setting format', () => {
+      const parsed = JSON.parse(sampleMixedJson)
+      expect(isValidSettingJson([parsed[0]])).toBe(true)
+    })
+
+    it('second item should be in MasterData format', () => {
+      const parsed = JSON.parse(sampleMixedJson)
+      expect(isValidMasterDataJson([parsed[1]])).toBe(true)
+    })
+  })
+})

--- a/packages/master/src/modules/master-settings/components/AddJsonData.tsx
+++ b/packages/master/src/modules/master-settings/components/AddJsonData.tsx
@@ -3,7 +3,13 @@
 import { SaveIcon } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { AxiosError } from 'axios'
 import DownloadJSONButton from '../../../components/buttons/DownloadJSONButton'
 import ImportJSONButton from '../../../components/buttons/ImportJSONButton'
@@ -272,9 +278,9 @@ export default function AddJsonData({
   const [value, setValue] = useState<string>('')
   const [submitting, setSubmitting] = useState(false)
   const [open, setOpen] = useState(false)
-  const [savedResults, setSavedResults] = useState<
-    (SettingDataEntity | DataSettingDataEntity)[]
-  >([])
+  const savedResultsRef = useRef<(SettingDataEntity | DataSettingDataEntity)[]>(
+    []
+  )
   const [expectedCount, setExpectedCount] = useState(0)
   const httpClient = useHttpClient()
   const [bulkTenant, setBulkTenant] = useState<string>(tenantCode)
@@ -313,10 +319,14 @@ export default function AddJsonData({
       setOpen(false)
 
       onSave?.({
-        settings: savedResults.length > 0 ? (savedResults as any) : undefined,
+        settings:
+          savedResultsRef.current.length > 0
+            ? (savedResultsRef.current as any)
+            : undefined,
       })
     }
-  }, [finishedCount, expectedCount, toast, stopBulk, savedResults, onSave])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [finishedCount, expectedCount, toast, stopBulk, onSave])
 
   const saveData = async () => {
     let parsedData: any
@@ -430,7 +440,7 @@ export default function AddJsonData({
         ...item,
         sk: removeSortKeyVersion(item.sk),
       }))
-      setSavedResults(processed)
+      savedResultsRef.current = processed
 
       const itemsWithRequestId = res.filter((item) => item.requestId)
       if (itemsWithRequestId.length === 0) {

--- a/packages/master/src/modules/master-settings/components/AddJsonData.tsx
+++ b/packages/master/src/modules/master-settings/components/AddJsonData.tsx
@@ -15,12 +15,7 @@ import { useSubscribeBulkCommandStatus } from '../../../lib/hook/useSubscribeMes
 import { removeSortKeyVersion } from '../../../lib/utils/removeSortKeyVersion'
 import { useHttpClient } from '../../../provider'
 import { DataSettingDataEntity, SettingDataEntity } from '../../../types'
-import {
-  isValidMasterDataJson,
-  isValidSettingJson,
-  sampleMixedJson,
-  sampleSettingJson,
-} from '../schema'
+import { isValidBulkJson, sampleMixedJson } from '../schema'
 import JSONEditorComponent from '../../../components/JSONEditorComponent'
 import { ExceptionBase } from '../../../exceptions/exception-base'
 
@@ -65,58 +60,31 @@ export type MappedData = {
 }
 export type MapResult = MappedSetting | MappedData
 
-// Detection functions to identify item types
-function isMasterSettingsItem(item: any): boolean {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'code' in item &&
-    'name' in item &&
-    'attributes' in item &&
-    typeof item.attributes === 'object' &&
-    item.attributes !== null &&
-    Array.isArray(item.attributes.fields)
-  )
-}
-
-function isMasterDataItem(item: any): boolean {
-  return (
-    typeof item === 'object' &&
-    item !== null &&
-    'settingCode' in item &&
-    'code' in item &&
-    'name' in item &&
-    'attributes' in item &&
-    'seq' in item &&
-    typeof item.seq === 'number'
-  )
-}
-
-// Split data array into Settings, Data, and Invalid items
-function splitDataByType(data: any[]): {
-  settings: any[]
-  data: any[]
-  invalid: any[]
+// Convert MapResult items to unified bulk format
+function mapResultToBulkItem(m: MapResult): {
+  name: string
+  code: string
+  attributes: object
+  tenantCode?: string
+  settingCode?: string
+  seq?: number
 } {
-  const settings: any[] = []
-  const dataItems: any[] = []
-  const invalid: any[] = []
-
-  for (const item of data) {
-    const isSettings = isMasterSettingsItem(item)
-    const isData = isMasterDataItem(item)
-
-    // Prioritize Data over Settings if both match
-    if (isData) {
-      dataItems.push(item)
-    } else if (isSettings) {
-      settings.push(item)
-    } else {
-      invalid.push(item)
+  if (m.kind === 'setting') {
+    return {
+      name: m.value.name,
+      code: m.value.code,
+      tenantCode: m.value.tenantCode,
+      attributes: m.value.settingValue,
     }
   }
-
-  return { settings, data: dataItems, invalid }
+  return {
+    name: m.value.name,
+    code: m.value.code,
+    settingCode: m.value.settingCode,
+    tenantCode: m.value.tenantCode,
+    seq: m.value.seq,
+    attributes: m.value.attributes,
+  }
 }
 
 function ModalContent({
@@ -304,29 +272,24 @@ export default function AddJsonData({
   const [value, setValue] = useState<string>('')
   const [submitting, setSubmitting] = useState(false)
   const [open, setOpen] = useState(false)
-  const [savedSettingsData, setSavedSettingsData] = useState<
-    SettingDataEntity[]
+  const [savedResults, setSavedResults] = useState<
+    (SettingDataEntity | DataSettingDataEntity)[]
   >([])
-  const [savedDataData, setSavedDataData] = useState<DataSettingDataEntity[]>(
-    []
-  )
-  const [settingsExpectedCount, setSettingsExpectedCount] = useState(0)
-  const [dataExpectedCount, setDataExpectedCount] = useState(0)
+  const [expectedCount, setExpectedCount] = useState(0)
   const httpClient = useHttpClient()
-  const [settingsTenant, setSettingsTenant] = useState<string>(tenantCode)
-  const [dataTenant, setDataTenant] = useState<string>(tenantCode)
+  const [bulkTenant, setBulkTenant] = useState<string>(tenantCode)
 
   const {
-    start: startSettings,
-    stop: stopSettings,
-    finishedCount: settingsFinishedCount,
-  } = useSubscribeBulkCommandStatus(settingsTenant, () => {
-    // Timeout callback for Settings
+    start: startBulk,
+    stop: stopBulk,
+    finishedCount,
+  } = useSubscribeBulkCommandStatus(bulkTenant, () => {
+    // Timeout callback
     setSubmitting(false)
     setOpen(false)
-    setSettingsExpectedCount(0)
+    setExpectedCount(0)
     toast({
-      title: 'マスター設定の登録に失敗しました。',
+      title: 'マスターデータの反映に失敗しました。',
       description:
         'タイムアウトしました。入力内容を確認した上で再度やり直してください。',
       variant: 'destructive',
@@ -334,98 +297,26 @@ export default function AddJsonData({
     router.refresh()
   })
 
-  const {
-    start: startData,
-    stop: stopData,
-    finishedCount: dataFinishedCount,
-  } = useSubscribeBulkCommandStatus(dataTenant, () => {
-    // Timeout callback for Data
-    setSubmitting(false)
-    setOpen(false)
-    setDataExpectedCount(0)
-    toast({
-      title: 'マスターデータの登録に失敗しました。',
-      description:
-        'タイムアウトしました。入力内容を確認した上で再度やり直してください。',
-      variant: 'destructive',
-    })
-    router.refresh()
-  })
-
-  // Track when all items are finished - Settings
+  // Track when all items are finished
   useEffect(() => {
-    if (settingsFinishedCount === 0 || settingsExpectedCount === 0) return
+    if (finishedCount === 0 || expectedCount === 0) return
 
-    // Show toast for each completed item
     toast({
-      description: `マスター設定を登録しました (${settingsFinishedCount}/${settingsExpectedCount})`,
+      description: `マスターデータを反映しました (${finishedCount}/${expectedCount})`,
       variant: 'success',
     })
 
-    // Check if all items are finished
-    if (settingsFinishedCount >= settingsExpectedCount) {
-      stopSettings()
-      setSettingsExpectedCount(0)
-    }
-  }, [settingsFinishedCount, settingsExpectedCount, toast, stopSettings])
-
-  // Track when all items are finished - Data
-  useEffect(() => {
-    if (dataFinishedCount === 0 || dataExpectedCount === 0) return
-
-    // Show toast for each completed item
-    toast({
-      description: `マスターデータを登録しました (${dataFinishedCount}/${dataExpectedCount})`,
-      variant: 'success',
-    })
-
-    // Check if all items are finished
-    if (dataFinishedCount >= dataExpectedCount) {
-      stopData()
-      setDataExpectedCount(0)
-    }
-  }, [dataFinishedCount, dataExpectedCount, toast, stopData])
-
-  // Check if both operations complete
-  useEffect(() => {
-    // Check if Settings are complete (either not started or all finished)
-    const settingsComplete =
-      settingsExpectedCount === 0 ||
-      (settingsExpectedCount > 0 &&
-        settingsFinishedCount >= settingsExpectedCount)
-
-    // Check if Data are complete (either not started or all finished)
-    const dataComplete =
-      dataExpectedCount === 0 ||
-      (dataExpectedCount > 0 && dataFinishedCount >= dataExpectedCount)
-
-    // Only proceed if at least one operation was started and both are complete
-    const hasStartedOperation =
-      settingsExpectedCount > 0 || dataExpectedCount > 0
-    const bothComplete = settingsComplete && dataComplete
-
-    if (bothComplete && hasStartedOperation && submitting) {
+    if (finishedCount >= expectedCount) {
+      stopBulk()
+      setExpectedCount(0)
       setSubmitting(false)
       setOpen(false)
-      setSettingsExpectedCount(0)
-      setDataExpectedCount(0)
 
-      // Call onSave to refresh data
       onSave?.({
-        settings: savedSettingsData.length > 0 ? savedSettingsData : undefined,
-        data: savedDataData.length > 0 ? savedDataData : undefined,
+        settings: savedResults.length > 0 ? (savedResults as any) : undefined,
       })
     }
-  }, [
-    settingsFinishedCount,
-    settingsExpectedCount,
-    dataFinishedCount,
-    dataExpectedCount,
-    savedSettingsData,
-    savedDataData,
-    onSave,
-    submitting,
-  ])
+  }, [finishedCount, expectedCount, toast, stopBulk, savedResults, onSave])
 
   const saveData = async () => {
     let parsedData: any
@@ -449,283 +340,124 @@ export default function AddJsonData({
       return
     }
 
+    let bulkItems: {
+      name: string
+      code: string
+      attributes: object
+      tenantCode?: string
+      settingCode?: string
+      seq?: number
+    }[]
+
     // If mapper provided, transform first
     if (mapRawItem) {
       const mapped = parsedData
         .map((item: any) => mapRawItem(item))
         .filter(Boolean) as MapResult[]
 
-      const mappedSettings = mapped
-        .filter((m) => m.kind === 'setting')
-        .map((m) => (m as MappedSetting).value)
-      const mappedData = mapped
-        .filter((m) => m.kind === 'data')
-        .map((m) => (m as MappedData).value)
-
-      if (mappedSettings.length === 0 && mappedData.length === 0) {
+      if (mapped.length === 0) {
         toast({ title: 'データがありません', variant: 'destructive' })
         return
       }
 
-      // Basic validation for mapped settings
-      const invalidSettings = mappedSettings.filter(
-        (x) =>
-          !x ||
-          typeof x.name !== 'string' ||
-          typeof x.code !== 'string' ||
-          typeof x.settingValue !== 'object'
-      )
-      if (invalidSettings.length > 0) {
+      // Validate mapped results
+      for (const m of mapped) {
+        if (m.kind === 'setting') {
+          if (
+            typeof m.value.name !== 'string' ||
+            typeof m.value.code !== 'string' ||
+            typeof m.value.settingValue !== 'object'
+          ) {
+            toast({
+              title: 'マッピング結果が無効です',
+              description:
+                '設定データの name, code は文字列、settingValue はオブジェクトである必要があります。',
+              variant: 'destructive',
+            })
+            return
+          }
+        } else {
+          if (
+            typeof m.value.settingCode !== 'string' ||
+            typeof m.value.code !== 'string' ||
+            typeof m.value.name !== 'string' ||
+            typeof m.value.seq !== 'number' ||
+            typeof m.value.attributes !== 'object'
+          ) {
+            toast({
+              title: 'マッピング結果が無効です',
+              description:
+                'データの settingCode, code, name は文字列、seq は数値、attributes はオブジェクトである必要があります。',
+              variant: 'destructive',
+            })
+            return
+          }
+        }
+      }
+
+      bulkItems = mapped.map(mapResultToBulkItem)
+    } else {
+      // Validate using unified bulk validation
+      if (!isValidBulkJson(parsedData)) {
         toast({
-          title: 'マッピング結果が無効です',
+          title: 'JSON が無効です',
           description:
-            '設定データの name, code は文字列、settingValue はオブジェクトである必要があります。',
+            '各項目には code, name, attributes が必須です。マスターデータの場合は settingCode, seq も必須です。',
           variant: 'destructive',
         })
         return
       }
 
-      // Basic validation for mapped data
-      const invalidData = mappedData.filter(
-        (x) =>
-          !x ||
-          typeof x.settingCode !== 'string' ||
-          typeof x.code !== 'string' ||
-          typeof x.name !== 'string' ||
-          typeof x.seq !== 'number' ||
-          typeof x.attributes !== 'object'
-      )
-      if (invalidData.length > 0) {
-        toast({
-          title: 'マッピング結果が無効です',
-          description:
-            'データの settingCode, code, name は文字列、seq は数値、attributes はオブジェクトである必要があります。',
-          variant: 'destructive',
-        })
-        return
-      }
-
-      setSubmitting(true)
-
-      // Process mapped settings
-      if (mappedSettings.length > 0) {
-        try {
-          const res = (
-            await httpClient.post<SettingDataEntity[]>(
-              API_URLS.SETTING.CREATE_BULK,
-              {
-                items: mappedSettings,
-              }
-            )
-          ).data
-
-          if (!res?.[0]?.requestId) {
-            toast({
-              title: 'マスター設定の登録に失敗しました。',
-              description: '入力内容を確認した上で再度やり直してください。',
-              variant: 'destructive',
-            })
-            setSubmitting(false)
-            return
-          }
-          // Switch listening tenant to mapped tenant if provided
-          const mappedTenant = mappedSettings[0]?.tenantCode || tenantCode
-          setSettingsTenant(mappedTenant)
-          setSettingsExpectedCount(res.length)
-          startSettings(res[0].requestId)
-          setSavedSettingsData(
-            res.map((item) => ({
-              ...item,
-              sk: removeSortKeyVersion(item.sk),
-            }))
-          )
-        } catch (error) {
-          console.error(error)
-          const errorMessage = getErrorMessage(error)
-          toast({
-            title: 'マスター設定の登録に失敗しました。',
-            description: errorMessage,
-            variant: 'destructive',
-          })
-          setSubmitting(false)
-          return
-        }
-      }
-
-      // Process mapped data
-      if (mappedData.length > 0) {
-        try {
-          const res = (
-            await httpClient.post<DataSettingDataEntity[]>(
-              API_URLS.DATA.CREATE_BULK,
-              {
-                items: mappedData,
-              }
-            )
-          ).data
-
-          if (!res?.[0]?.requestId) {
-            toast({
-              title: 'マスターデータの登録に失敗しました。',
-              description: '入力内容を確認した上で再度やり直してください。',
-              variant: 'destructive',
-            })
-            setSubmitting(false)
-            return
-          }
-          // Switch listening tenant to mapped tenant if provided
-          const mappedTenant = mappedData[0]?.tenantCode || tenantCode
-          setDataTenant(mappedTenant)
-          setDataExpectedCount(res.length)
-          startData(res[0].requestId)
-          setSavedDataData(
-            res.map((item) => ({
-              ...item,
-              sk: removeSortKeyVersion(item.sk),
-            }))
-          )
-        } catch (error) {
-          console.error(error)
-          const errorMessage = getErrorMessage(error)
-          toast({
-            title: 'マスターデータの登録に失敗しました。',
-            description: errorMessage,
-            variant: 'destructive',
-          })
-          setSubmitting(false)
-          return
-        }
-      }
-
-      return
+      bulkItems = parsedData
     }
 
-    // Split data by type
-    const { settings, data: dataItems, invalid } = splitDataByType(parsedData)
-
-    if (invalid.length > 0) {
-      toast({
-        title: 'JSON が無効です',
-        description: `${invalid.length}個の項目が認識できませんでした。`,
-        variant: 'destructive',
-      })
-      return
-    }
-
-    if (settings.length === 0 && dataItems.length === 0) {
+    if (bulkItems.length === 0) {
       toast({ title: 'データがありません', variant: 'destructive' })
       return
     }
 
     setSubmitting(true)
 
-    // Process Settings if present
-    if (settings.length > 0) {
-      if (!isValidSettingJson(settings)) {
-        toast({
-          title: 'マスター設定のJSONが無効です',
-          variant: 'destructive',
-        })
+    try {
+      const res = (
+        await httpClient.post<(SettingDataEntity | DataSettingDataEntity)[]>(
+          API_URLS.MASTER.BULK,
+          { items: bulkItems }
+        )
+      ).data
+
+      const processed = res.map((item) => ({
+        ...item,
+        sk: removeSortKeyVersion(item.sk),
+      }))
+      setSavedResults(processed)
+
+      const itemsWithRequestId = res.filter((item) => item.requestId)
+      if (itemsWithRequestId.length === 0) {
         setSubmitting(false)
-        return
-      }
-
-      try {
-        const res = (
-          await httpClient.post<SettingDataEntity[]>(
-            API_URLS.SETTING.CREATE_BULK,
-            {
-              items: settings.map((item) => ({
-                ...item,
-                settingValue: {
-                  ...item.attributes,
-                },
-              })),
-            }
-          )
-        ).data
-
-        if (!res?.[0].requestId) {
-          toast({
-            title: 'マスター設定の登録に失敗しました。',
-            description: '入力内容を確認した上で再度やり直してください。',
-            variant: 'destructive',
-          })
-          setSubmitting(false)
-          return
-        } else {
-          setSettingsExpectedCount(res.length)
-          startSettings(res[0].requestId)
-          setSavedSettingsData(
-            res.map((item) => ({
-              ...item,
-              sk: removeSortKeyVersion(item.sk),
-            }))
-          )
-        }
-      } catch (error) {
-        console.error(error)
-        const errorMessage = getErrorMessage(error)
+        setOpen(false)
         toast({
-          title: 'マスター設定の登録に失敗しました。',
-          description: errorMessage,
-          variant: 'destructive',
+          description: 'データに変更はありませんでした。',
+          variant: 'success',
         })
-        setSubmitting(false)
-        return
-      }
-    }
-
-    // Process Data if present
-    if (dataItems.length > 0) {
-      if (!isValidMasterDataJson(dataItems)) {
-        toast({
-          title: 'マスターデータのJSONが無効です',
-          variant: 'destructive',
+        onSave?.({
+          settings: processed.length > 0 ? (processed as any) : undefined,
         })
-        setSubmitting(false)
-        return
+      } else {
+        const itemTenant = bulkItems[0]?.tenantCode || tenantCode
+        setBulkTenant(itemTenant)
+        setExpectedCount(itemsWithRequestId.length)
+        startBulk(itemsWithRequestId[0].requestId)
       }
-
-      try {
-        const res = (
-          await httpClient.post<DataSettingDataEntity[]>(
-            API_URLS.DATA.CREATE_BULK,
-            {
-              items: dataItems,
-            }
-          )
-        ).data
-
-        if (!res?.[0].requestId) {
-          toast({
-            title: 'マスターデータの登録に失敗しました。',
-            description: '入力内容を確認した上で再度やり直してください。',
-            variant: 'destructive',
-          })
-          setSubmitting(false)
-          return
-        } else {
-          setDataExpectedCount(res.length)
-          startData(res[0].requestId)
-          setSavedDataData(
-            res.map((item) => ({
-              ...item,
-              sk: removeSortKeyVersion(item.sk),
-            }))
-          )
-        }
-      } catch (error) {
-        console.error(error)
-        const errorMessage = getErrorMessage(error)
-        toast({
-          title: 'マスターデータの登録に失敗しました。',
-          description: errorMessage,
-          variant: 'destructive',
-        })
-        setSubmitting(false)
-        return
-      }
+    } catch (error) {
+      console.error(error)
+      const errorMessage = getErrorMessage(error)
+      toast({
+        title: 'マスターデータの反映に失敗しました。',
+        description: errorMessage,
+        variant: 'destructive',
+      })
+      setSubmitting(false)
     }
   }
 

--- a/packages/master/src/modules/master-settings/components/__tests__/AddJsonData.test.tsx
+++ b/packages/master/src/modules/master-settings/components/__tests__/AddJsonData.test.tsx
@@ -1,0 +1,320 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { AxiosError } from 'axios'
+
+// --- Mocks ---
+
+const mockToast = jest.fn()
+jest.mock('../../../../components/ui/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+    toasts: [],
+    dismiss: jest.fn(),
+  }),
+}))
+
+const mockPost = jest.fn()
+jest.mock('../../../../provider', () => ({
+  useHttpClient: () => ({
+    post: mockPost,
+  }),
+}))
+
+const mockStart = jest.fn()
+const mockStop = jest.fn()
+let subscribedFinishedCount = 0
+
+jest.mock('../../../../lib/hook/useSubscribeMessage', () => ({
+  useSubscribeBulkCommandStatus: (
+    _tenantCode: string,
+    onTimeout: () => void
+  ) => {
+    return {
+      start: mockStart,
+      stop: mockStop,
+      finishedCount: subscribedFinishedCount,
+    }
+  },
+}))
+
+jest.mock('../../../../lib/utils/removeSortKeyVersion', () => ({
+  removeSortKeyVersion: (sk: string) => sk.replace(/@.*$/, ''),
+}))
+
+const mockRouterRefresh = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}))
+
+jest.mock('next/dynamic', () => () => {
+  return function DynamicComponent() {
+    return null
+  }
+})
+
+let mockOnChangeText: ((json: string) => void) | null = null
+jest.mock('../../../../components/JSONEditorComponent', () => {
+  return function MockJSONEditor({
+    text,
+    onChangeText,
+  }: {
+    text: string
+    onChangeText: (json: string) => void
+  }) {
+    mockOnChangeText = onChangeText
+    return <textarea data-testid="json-editor" defaultValue={text} />
+  }
+})
+
+jest.mock('../../../../components/DragResizeModal', () => {
+  const Modal = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  Modal.Open = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  Modal.Window = ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+  return Modal
+})
+
+jest.mock('../../../../components/buttons/DownloadJSONButton', () => {
+  return function MockDownloadButton() {
+    return null
+  }
+})
+
+jest.mock('../../../../components/buttons/ImportJSONButton', () => {
+  return function MockImportButton() {
+    return null
+  }
+})
+
+// Import after mocks
+import AddJsonData from '../AddJsonData'
+import { ExceptionBase } from '../../../../exceptions/exception-base'
+
+// Concrete subclass for testing
+class TestException extends ExceptionBase {}
+
+// Helper to set JSON value and trigger save
+async function setValueAndSave(jsonStr: string) {
+  await act(async () => {
+    mockOnChangeText?.(jsonStr)
+  })
+  const saveButton = screen.getByText('データ反映')
+  await act(async () => {
+    fireEvent.click(saveButton)
+  })
+}
+
+describe('master-settings/AddJsonData', () => {
+  const defaultProps = {
+    tenantCode: 'TEST_TENANT',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    subscribedFinishedCount = 0
+    mockOnChangeText = null
+  })
+
+  describe('getErrorMessage (via API error handling)', () => {
+    it('should extract message from ExceptionBase', async () => {
+      const error = new TestException({ message: 'カスタムエラー' })
+      mockPost.mockRejectedValue(error)
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: 'カスタムエラー',
+            variant: 'destructive',
+          })
+        )
+      })
+    })
+
+    it('should extract message from AxiosError response', async () => {
+      const axiosError = new AxiosError('Request failed')
+      axiosError.response = {
+        data: { message: 'バリデーションエラー' },
+        status: 400,
+        statusText: 'Bad Request',
+        headers: {},
+        config: {} as any,
+      }
+      mockPost.mockRejectedValue(axiosError)
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: 'バリデーションエラー',
+            variant: 'destructive',
+          })
+        )
+      })
+    })
+
+    it('should fallback for generic Error', async () => {
+      mockPost.mockRejectedValue(new Error('Generic error'))
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: 'Generic error',
+            variant: 'destructive',
+          })
+        )
+      })
+    })
+
+    it('should fallback for unknown error', async () => {
+      mockPost.mockRejectedValue('string error')
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: 'サーバーエラーが発生しました。',
+            variant: 'destructive',
+          })
+        )
+      })
+    })
+  })
+
+  describe('saveData validation', () => {
+    it('should show error toast for invalid JSON', async () => {
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave('not valid json {{{')
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'JSON が無効です',
+            variant: 'destructive',
+          })
+        )
+      })
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('should show error toast for non-array JSON', async () => {
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(JSON.stringify({ code: 'C', name: 'N' }))
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'JSON が無効です',
+            description: '配列である必要があります。',
+            variant: 'destructive',
+          })
+        )
+      })
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('should show error toast for invalid bulk JSON structure', async () => {
+      render(<AddJsonData {...defaultProps} />)
+
+      // Missing attributes
+      await setValueAndSave(JSON.stringify([{ code: 'C', name: 'N' }]))
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'JSON が無効です',
+            variant: 'destructive',
+          })
+        )
+      })
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('API success handling', () => {
+    it('should show "no changes" toast when no requestId returned', async () => {
+      const responseData = [
+        {
+          pk: 'MASTER#TEST_TENANT',
+          sk: 'SETTING_1#CODE_1@1',
+          id: 'id-1',
+          code: 'CODE_1',
+          name: 'Item 1',
+          version: 1,
+          attributes: {},
+        },
+      ]
+      mockPost.mockResolvedValue({ data: responseData })
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: 'データに変更はありませんでした。',
+            variant: 'success',
+          })
+        )
+      })
+      expect(mockStart).not.toHaveBeenCalled()
+    })
+
+    it('should start WebSocket subscription when requestId present', async () => {
+      const responseData = [
+        {
+          pk: 'MASTER#TEST_TENANT',
+          sk: 'SETTING_1#CODE_1@1',
+          id: 'id-1',
+          code: 'CODE_1',
+          name: 'Item 1',
+          version: 1,
+          requestId: 'req-123',
+          attributes: {},
+        },
+      ]
+      mockPost.mockResolvedValue({ data: responseData })
+
+      render(<AddJsonData {...defaultProps} />)
+
+      await setValueAndSave(
+        JSON.stringify([{ code: 'C', name: 'N', attributes: {} }])
+      )
+
+      await waitFor(() => {
+        expect(mockStart).toHaveBeenCalledWith('req-123')
+      })
+    })
+  })
+})

--- a/packages/master/src/modules/master-settings/schema.ts
+++ b/packages/master/src/modules/master-settings/schema.ts
@@ -160,3 +160,30 @@ export const isValidMasterDataJson = (data: any) => {
 
   return true
 }
+
+/**
+ * Validate unified bulk JSON format.
+ * Each item must have code, name, attributes.
+ * If settingCode is present, seq is also required (master data).
+ * If settingCode is absent, it's treated as a master setting.
+ */
+export const isValidBulkJson = (data: any) => {
+  if (!isArray(data)) {
+    return false
+  }
+  for (const item of data) {
+    if (!isObject(item)) return false
+    if (!('code' in item) || !('name' in item) || !('attributes' in item)) {
+      return false
+    }
+    if (!isObject(item.attributes)) {
+      return false
+    }
+    // If settingCode present, it's master data — seq is required
+    if ('settingCode' in item) {
+      if (typeof item.settingCode !== 'string') return false
+      if (!('seq' in item) || typeof item.seq !== 'number') return false
+    }
+  }
+  return true
+}

--- a/packages/master/src/provider.tsx
+++ b/packages/master/src/provider.tsx
@@ -163,3 +163,5 @@ export function AppProviders({
     </AppRootProvider>
   )
 }
+
+export { useLoadingStore } from './lib/stores/hooks'


### PR DESCRIPTION
- Add isValidBulkJson tests (13 cases) in schema.test.ts
- Add master-settings/AddJsonData component tests (9 cases)
- Strengthen master-data/ActionBar/AddJsonData tests (5 cases)
- Fix JSON.parse bug in edit-master-data and edit-master-settings (missing try/catch caused unhandled exceptions on invalid JSON)
- Add unified bulk API endpoint and validation schema