### PR TITLE
fix(master): correct MASTER.BULK API path to match backend controller

### DIFF
--- a/packages/master/src/lib/constants/url.ts
+++ b/packages/master/src/lib/constants/url.ts
@@ -110,7 +110,7 @@ export const API_URLS = {
     WITHOUT_PROVIDED_SETTING: '/sequence',
   },
   MASTER: {
-    BULK: '/master-bulk/bulk',
+    BULK: '/master-bulk',
   },
   HEALTH: '/',
   CCI: '/master/cci',


### PR DESCRIPTION
The MASTER.BULK path was set to '/master-bulk/bulk' but the backend MasterBulkController uses @Controller('api/master-bulk') with @Post('/'), so the correct path is '/master-bulk'. This caused 404 errors on JSON bulk import.